### PR TITLE
Use `npm ci` instead of `npm install`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
       - run:
           name: install-dev-packages
-          command: npm install
+          command: npm ci
       - run:
           name: install-lib-packages
           command: cd lib && npm install


### PR DESCRIPTION
https://snyk.io/blog/ten-npm-security-best-practices/